### PR TITLE
Segments visualization

### DIFF
--- a/pygm/sortedcontainer.py
+++ b/pygm/sortedcontainer.py
@@ -254,6 +254,12 @@ class SortedContainer(collections.abc.Sequence):
         d['typecode'] = self._typecode
         return d
 
+    def num_segments(self, level_num: int):
+        return self._impl.num_segments(level_num)
+
+    def segment(self, level_num: int, segment_num: int):
+        return self._impl.segment(level_num, segment_num)
+
     def __iter__(self):
         """Return an iterator over the elements of ``self``.
 

--- a/tests/benchmark.ipynb
+++ b/tests/benchmark.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "number = 50000\n",
     "sizes = [10 ** x for x in range(2, 8)]\n",
-    "gen_list_data = lambda s: np.sort(np.random.randint(0, 2 ** 40, s)).tolist()\n",
+    "gen_list_data = lambda s: np.sort(np.random.normal(0, 2 ** 40, s).astype(int)).tolist()\n",
     "gen_set_data = lambda s: sorted(random.sample(range(min(2 ** 32, s * 1000)) , s))"
    ]
   },
@@ -396,18 +396,91 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore PGM segments"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "def plot_segments(pgm_idx, level=0):\n",
+    "    \n",
+    "    seg0 = pgm_idx.segment(level, 0)\n",
+    "    plt.title(f\"level={level} eps={int(seg0['epsilon'])}\")\n",
+    "    \n",
+    "    segments_count = pgm_idx.num_segments(level)\n",
+    "    for seg_num in range(0, segments_count):\n",
+    "        seg = pgm_idx.segment(level, seg_num)\n",
+    "\n",
+    "        x_start = seg['key']\n",
+    "\n",
+    "        if seg_num == segments_count - 1:\n",
+    "            x_stop = pgm_idx[-1]\n",
+    "        else:\n",
+    "            x_stop = pgm_idx.segment(level, seg_num+1)['key']\n",
+    "\n",
+    "        x_vals = np.array([ x_start, x_stop ])\n",
+    "        y_vals = seg['intercept'] + seg['slope'] * (x_vals - seg['key'])\n",
+    "\n",
+    "        eps = seg['epsilon']\n",
+    "        plt.gca().fill_between(x_vals, y_vals - eps, y_vals + eps, alpha=0.5, label=f'segment {seg_num}')\n",
+    "\n",
+    "    if level > 0:\n",
+    "        prev_level = level - 1\n",
+    "        prev_level_segments_count = pgm_idx.num_segments(prev_level)\n",
+    "        intercepts = []\n",
+    "        keys = []\n",
+    "        for seg_num in range(0, prev_level_segments_count):\n",
+    "            seg = pgm_idx.segment(prev_level, seg_num)\n",
+    "            intercepts.append(seg['intercept'])\n",
+    "            keys.append(seg['key'])\n",
+    "\n",
+    "        plt.scatter(keys, range(len(keys)), marker='X', label=f'level {prev_level} keys')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pygm_idx = pygm.SortedList(gen_list_data(1000), epsilon=16)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_segments(pygm_idx, level=0)\n",
+    "\n",
+    "plt.scatter(pygm_idx, range(len(pygm_idx)), s=1, alpha=0.1, color='blue')\n",
+    "\n",
+    "plt.gcf().set_size_inches((15,5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_segments(pygm_idx, level=1)\n",
+    "plt.gcf().set_size_inches((15,5))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.6.8 64-bit ('miniconda3': virtualenv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python36864bitminiconda3virtualenvbaf5a8f430fc4802aed8a51649c1d5fb"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -419,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tests/benchmark.ipynb
+++ b/tests/benchmark.ipynb
@@ -408,6 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "def plot_segments(pgm_idx, level=0):\n",
     "    \n",
     "    seg0 = pgm_idx.segment(level, 0)\n",


### PR DESCRIPTION
Add visualization of segments for PGM index.

I made `gen_list_data` function to generate normally distributed data. PGM-index built on uniform distribution has only one segment.

[**Notebook**](https://colab.research.google.com/drive/1srdW-Ol2piIZzbh04LVwvZw_4M3whkI9?usp=sharing) with visualized segments